### PR TITLE
add request controllers

### DIFF
--- a/server/controllers/requests.js
+++ b/server/controllers/requests.js
@@ -1,0 +1,72 @@
+const mongoose = require("mongoose");
+const asycnHandler = require("express-async-handler");
+const Request = require("../models/Requests");
+const Requests = require("../models/Requests");
+const Profile = require("../models/Profile");
+
+// @route POST /request
+// Add a new request
+exports.newRequest = asycnHandler(async (req, res, next) => {
+    const request = req.body;
+    const newRequest = new Request({ ...request});
+
+    if(!newRequest) {
+        res.status(500);
+        throw new Error("Request could not be made.");
+    }
+    await newRequest.save();
+    res.status(200).json({ request: newRequest});
+});
+
+// @route GET /request
+// Get all users requests
+exports.userRequests = asycnHandler(async (req, res, next) => {
+    const id = req.params.user.id;
+    //find all the requests that have the users id, or sitter id
+    //this will include pending *and* completed requests, which can
+    //be handled by the front end, in order to display an accurate
+    //history, we can also group them in the app in case there are
+    //users who both are sitters, and use the app to find sitters
+    const requests = await Requests.find(
+        { $or: [{"user.id": id}, {"sitter.id": id}]
+    });
+    if(!requests) {
+        res.status(400);
+        throw new Error("No requests with that ID");
+    }
+    await userRequests.save();
+    res.status(200).json({ request = userRequests});
+});
+
+// @route PATCH /request/:requestId
+// Edit a request with matching userId
+exports.editRequest = asycnHandler(async (req, res, next) => {
+    const id = req.params.requestId;
+    const request = req.body;
+
+    try {
+        const editedRequest = await Profile.findByIdAndUpdate(id, request, { new: true,});
+        res.status(201).json({ success: { request : editedRequest } });
+    } catch (error) {
+        res.status(500);
+        throw new Error("Could not update request.");
+    }
+});
+
+// @route DELETE /request/:requestId
+// Delete a request with matching requestId
+exports.deleteRequest = asycnHandler(async (req, res, next) => {
+    const id = req.params.requestId;
+    const request = Request.findbyId(id);
+    if(!request) {
+        res.status(404);
+        throw new Error("Cannot find request to delete.");
+    }
+    try {
+        Request.findbyIdAndDelete(id);
+        res.status(200);
+    } catch (error) {
+        res.status(500);
+        throw new Error("Could not delete request.");
+    }
+});

--- a/server/controllers/requests.js
+++ b/server/controllers/requests.js
@@ -22,11 +22,6 @@ exports.newRequest = asycnHandler(async (req, res, next) => {
 // Get all users requests
 exports.userRequests = asycnHandler(async (req, res, next) => {
     const id = req.params.user.id;
-    //find all the requests that have the users id, or sitter id
-    //this will include pending *and* completed requests, which can
-    //be handled by the front end, in order to display an accurate
-    //history, we can also group them in the app in case there are
-    //users who both are sitters, and use the app to find sitters
     const requests = await Requests.find(
         { $or: [{"user.id": id}, {"sitter.id": id}]
     });

--- a/server/controllers/requests.js
+++ b/server/controllers/requests.js
@@ -36,7 +36,7 @@ exports.userRequests = asycnHandler(async (req, res, next) => {
 // @route PATCH /request/:requestId
 // Edit a request with matching userId
 exports.editRequest = asycnHandler(async (req, res, next) => {
-    const id = req.params.requestId;
+    const id = req.params._id;
     const request = req.body;
 
     try {
@@ -51,7 +51,7 @@ exports.editRequest = asycnHandler(async (req, res, next) => {
 // @route DELETE /request/:requestId
 // Delete a request with matching requestId
 exports.deleteRequest = asycnHandler(async (req, res, next) => {
-    const id = req.params.requestId;
+    const id = req.params._id;
     const request = Request.findbyId(id);
     if(!request) {
         res.status(404);

--- a/server/models/Requests.js
+++ b/server/models/Requests.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const AutoIncrement = require("mongoose-sequence")(mongoose);
 
 const requestSchema = new mongoose.Schema({
   user: {
@@ -36,5 +37,6 @@ const requestSchema = new mongoose.Schema({
     default: false,
   },
 });
+requestSchema.plugin(AutoIncrement, {id: 'request_seq', inc_field: 'requestId'});
 
 module.exports = Request = mongoose.model("request", requestSchema);

--- a/server/models/Requests.js
+++ b/server/models/Requests.js
@@ -1,5 +1,4 @@
 const mongoose = require("mongoose");
-const AutoIncrement = require("mongoose-sequence")(mongoose);
 
 const requestSchema = new mongoose.Schema({
   user: {
@@ -37,6 +36,5 @@ const requestSchema = new mongoose.Schema({
     default: false,
   },
 });
-requestSchema.plugin(AutoIncrement, {id: 'request_seq', inc_field: 'requestId'});
 
 module.exports = Request = mongoose.model("request", requestSchema);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -161,6 +161,14 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1523,6 +1531,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mongoose-sequence": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/mongoose-sequence/-/mongoose-sequence-5.3.1.tgz",
+      "integrity": "sha512-kQB1ctCdAQT8YdQzoHV0CpBRsO4RNVy03SOkzM6TQKBbGBs1ZgVS4UlKsuvBPaiPt9q5tKgQZvorGJ1awbHDqA==",
+      "requires": {
+        "async": "^2.5.0",
+        "lodash": "^4.17.20"
+      }
     },
     "morgan": {
       "version": "1.10.0",

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "http-errors": "~1.8.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.12.8",
+    "mongoose-sequence": "^5.3.1",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.6",
     "socket.io": "^4.1.0"


### PR DESCRIPTION
### What this PR does (required):
Add controllers for the request feature. I built the controllers based on the idea that the user would search for all of their active/inactive requests and then interact with them from there. That is what would allow us to use the requestId field (added in the Request model) to quickly and safely delete individual requests

### Screenshots / Videos (required):
N/A

### Any information needed to test this feature (required):
You must run npm install to get the packages required. This PR adds the "mongoose-sequences" package, which enables mongoose to automatically create an id field ass new requests are submitted, meaning we can safely delete 1 request at a time, we can also delete many requests through iteration on the front end.

### Any issues with the current functionality (optional):
From the above, I think perhaps we should add the ability to delete an entire user/sitter batch of requests. Like cancelling a recurring request.
