### PR TITLE
Fix routing/page organization

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,7 +27,7 @@ function App(): JSX.Element {
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/profile" component={SitterProfile} />
-                <ProtectedRoutes path="/manageprofile" component={ManageProfile} />
+                <ProtectedRoutes path="/manage-profile" component={ManageProfile} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,12 +13,7 @@ import { SnackBarProvider } from './context/useSnackbarContext';
 import ProtectedRoutes from './components/ProtectedRoutes/ProtectedRoutes';
 
 import './App.css';
-import EditProfile from './components/EditProfile/EditProfile';
-import ProfilePhoto from './components/ProfilePhoto/ProfilePhoto';
-import Payment from './components/Payment/Payment';
-import Availability from './components/Availability/Availability';
-import Security from './components/Security/Security';
-import Settings from './components/Settings/Settings';
+import ManageProfile from './pages/ManageProfile/ManageProfile';
 
 function App(): JSX.Element {
   return (
@@ -31,13 +26,8 @@ function App(): JSX.Element {
                 <Route exact path="/landingpage" component={LandingPage} />
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/editprofile" component={EditProfile} />
-                <Route exact path="/payment" component={Payment} />
-                <Route exact path="/availability" component={Availability} />
-                <Route exact path="/security" component={Security} />
-                <Route exact path="/settings" component={Settings} />
-                <Route exact path="/profile/pics" component={ProfilePhoto} />
                 <Route exact path="/profile" component={SitterProfile} />
+                <ProtectedRoutes path="/manageprofile" component={ManageProfile} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>

--- a/client/src/components/Availability/Availability.tsx
+++ b/client/src/components/Availability/Availability.tsx
@@ -1,19 +1,11 @@
-import { Grid, Paper } from '@material-ui/core';
-import Sidebar from '../Sidebar/SideBar';
+import { Grid } from '@material-ui/core';
 import useStyles from './useStyles';
 
 const Availability = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Grid container>
-      <Grid item xs={2}>
-        <Sidebar></Sidebar>
-      </Grid>
-      <Grid item xs={10}>
-        <Paper className={classes.root} elevation={2}>
-          <h1>Availability</h1>
-        </Paper>
-      </Grid>
+    <Grid>
+      <h1>Availability</h1>
     </Grid>
   );
 };

--- a/client/src/components/EditProfile/EditProfile.tsx
+++ b/client/src/components/EditProfile/EditProfile.tsx
@@ -1,19 +1,15 @@
-import { TextField, Paper, Grid, Typography, Button, CircularProgress } from '@material-ui/core';
+import { TextField, Grid, Typography, Button, CircularProgress } from '@material-ui/core';
 import useStyles from './useStyles';
-import Sidebar from '../Sidebar/SideBar';
 import { useSnackBar } from '../../context/useSnackbarContext';
 import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import editProfile from '../../helpers/APICalls/editProfile';
+import createProfile from '../../helpers/APICalls/createProfile';
+import { Profile } from '../../interface/Profile';
 
 interface Props {
   _id?: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  phone?: number;
-  city?: string;
-  description?: string;
+  profile?: Profile;
 }
 
 const EditProfile = (props: Props): JSX.Element => {
@@ -21,187 +17,198 @@ const EditProfile = (props: Props): JSX.Element => {
   const { updateSnackBarMessage } = useSnackBar();
 
   const handleSubmit = (
-    { firstName, lastName, email, phone, city, description }: Props,
-    { setSubmitting }: FormikHelpers<Props>,
+    { firstName, lastName, email, phone, city, description }: Profile,
+    { setSubmitting }: FormikHelpers<Profile>,
   ) => {
-    const id = props._id;
-    if (!id) {
+    const _id = props._id;
+    if (!_id) {
       setSubmitting(false);
       updateSnackBarMessage('Could not find profile');
       return;
     }
-    const profile = { firstName, lastName, email, phone, city, description };
-    editProfile(id, profile).then((data) => {
-      if (data.error) {
-        setSubmitting(false);
-        updateSnackBarMessage(data.error.message);
-      } else if (data.success) {
-        setSubmitting(false);
-        alert('Profile updated');
-      } else {
-        // For an unknown issue
-        console.error({ data });
+    if (!props.profile) {
+      const profile = { _id, firstName, lastName, email, phone, city, description };
+      createProfile(profile).then((data) => {
+        if (data.error) {
+          setSubmitting(false);
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          setSubmitting(false);
+          alert('Created a new Profile!');
+        } else {
+          // For an unknown issue
+          console.error({ data });
+          setSubmitting(false);
+          updateSnackBarMessage('An unexpected error occurred. Please try again');
+        }
+      });
+    } else {
+      const profile = { firstName, lastName, email, phone, city, description };
+      editProfile(_id, profile).then((data) => {
+        if (data.error) {
+          setSubmitting(false);
+          updateSnackBarMessage(data.error.message);
+        } else if (data.success) {
+          setSubmitting(false);
+          alert('Profile updated');
+        } else {
+          // For an unknown issue
+          console.error({ data });
 
-        setSubmitting(false);
-        updateSnackBarMessage('An unexpected error occurred. Please try again');
-      }
-    });
+          setSubmitting(false);
+          updateSnackBarMessage('An unexpected error occurred. Please try again');
+        }
+      });
+    }
   };
   return (
     <Grid container>
-      <Grid item xs={2}>
-        <Sidebar />
-      </Grid>
-      <Grid item xs={10} style={{ backgroundColor: '#FAFAFA' }}>
-        <Paper elevation={3} className={classes.gridContainer}>
-          <Typography variant="h3" className={classes.heading}>
-            Edit Profile
-          </Typography>
-          <Formik
-            initialValues={{
-              firstName: props.firstName,
-              lastName: props.lastName,
-              email: props.lastName,
-              phone: props.phone,
-              city: props.city,
-            }}
-            validationSchema={Yup.object().shape({
-              firstName: Yup.string().required('First name is required').max(20, 'First name is too long'),
-              lastName: Yup.string().required('Last name is required').max(20, 'Last name is too long'),
-              email: Yup.string().required('Email is required').email('Email is not valid'),
-              phone: Yup.number().notRequired(),
-              city: Yup.string().notRequired(),
-            })}
-            onSubmit={handleSubmit}
-          >
-            {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
-              <form onSubmit={handleSubmit} noValidate>
-                <Grid container>
-                  <Grid item xs={2} md={2} />
-                  <Grid item xs={2} md={2} className={classes.formLabel}>
-                    first name
-                  </Grid>
-                  <Grid item xs={6} md={6} className={classes.formInputField}>
-                    <TextField
-                      id="firstName"
-                      name="firstName"
-                      autoComplete="First Name"
-                      helperText={touched.firstName ? errors.firstName : ''}
-                      error={touched.firstName && Boolean(errors.firstName)}
-                      value={values.firstName}
-                      onChange={handleChange}
-                      variant="outlined"
-                      placeholder="First Name"
-                      fullWidth
-                      size={'small'}
-                    />
-                  </Grid>
-                  <Grid item xs={2} md={2} />
+      <Typography variant="h3" className={classes.heading}>
+        Edit Profile
+      </Typography>
+      <Formik
+        initialValues={{
+          firstName: props.profile?.firstName,
+          lastName: props.profile?.lastName,
+          email: props.profile?.email,
+          phone: props.profile?.phone,
+          city: props.profile?.city,
+        }}
+        validationSchema={Yup.object().shape({
+          firstName: Yup.string().required('First name is required').max(20, 'First name is too long'),
+          lastName: Yup.string().required('Last name is required').max(20, 'Last name is too long'),
+          email: Yup.string().required('Email is required').email('Email is not valid'),
+          phone: Yup.number().notRequired(),
+          city: Yup.string().notRequired(),
+        })}
+        onSubmit={handleSubmit}
+      >
+        {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
+          <form onSubmit={handleSubmit} noValidate>
+            <Grid container>
+              <Grid item xs={2} md={2} />
+              <Grid item xs={2} md={2} className={classes.formLabel}>
+                first name
+              </Grid>
+              <Grid item xs={6} md={6} className={classes.formInputField}>
+                <TextField
+                  id="firstName"
+                  name="firstName"
+                  autoComplete="First Name"
+                  helperText={touched.firstName ? errors.firstName : ''}
+                  error={touched.firstName && Boolean(errors.firstName)}
+                  value={values.firstName}
+                  onChange={handleChange}
+                  variant="outlined"
+                  placeholder="First Name"
+                  fullWidth
+                  size={'small'}
+                />
+              </Grid>
+              <Grid item xs={2} md={2} />
 
-                  <Grid item xs={2} />
-                  <Grid item xs={2} className={classes.formLabel}>
-                    last name
-                  </Grid>
-                  <Grid item xs={6} className={classes.formInputField}>
-                    <TextField
-                      id="lastName"
-                      name="lastName"
-                      autoComplete="Last Name"
-                      helperText={touched.lastName ? errors.lastName : ''}
-                      error={touched.lastName && Boolean(errors.lastName)}
-                      value={values.lastName}
-                      onChange={handleChange}
-                      size="small"
-                      variant="outlined"
-                      placeholder="Last Name"
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={2} />
+              <Grid item xs={2} />
+              <Grid item xs={2} className={classes.formLabel}>
+                last name
+              </Grid>
+              <Grid item xs={6} className={classes.formInputField}>
+                <TextField
+                  id="lastName"
+                  name="lastName"
+                  autoComplete="Last Name"
+                  helperText={touched.lastName ? errors.lastName : ''}
+                  error={touched.lastName && Boolean(errors.lastName)}
+                  value={values.lastName}
+                  onChange={handleChange}
+                  size="small"
+                  variant="outlined"
+                  placeholder="Last Name"
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={2} />
 
-                  <Grid item xs={2} />
-                  <Grid item xs={2} className={classes.formLabel}>
-                    email address
-                  </Grid>
-                  <Grid item xs={6} className={classes.formInputField}>
-                    <TextField
-                      id="email"
-                      name="email"
-                      autoComplete="email"
-                      helperText={touched.email ? errors.email : ''}
-                      error={touched.email && Boolean(errors.email)}
-                      value={values.email}
-                      onChange={handleChange}
-                      size="small"
-                      variant="outlined"
-                      placeholder="johndoe@gmail.com"
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={2} />
+              <Grid item xs={2} />
+              <Grid item xs={2} className={classes.formLabel}>
+                email address
+              </Grid>
+              <Grid item xs={6} className={classes.formInputField}>
+                <TextField
+                  id="email"
+                  name="email"
+                  autoComplete="email"
+                  helperText={touched.email ? errors.email : ''}
+                  error={touched.email && Boolean(errors.email)}
+                  value={values.email}
+                  onChange={handleChange}
+                  size="small"
+                  variant="outlined"
+                  placeholder="johndoe@gmail.com"
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={2} />
 
-                  <Grid item xs={2} />
-                  <Grid item xs={2} className={classes.formLabel}>
-                    phone number
-                  </Grid>
-                  <Grid item xs={6} className={classes.formInputField}>
-                    <Button color="primary" variant="outlined" className={classes.buttonPhone}>
-                      Add a phone number
-                    </Button>
-                  </Grid>
-                  <Grid item xs={2} />
-
-                  <Grid item xs={2} />
-                  <Grid item xs={2} className={classes.formLabel}>
-                    city you live in
-                  </Grid>
-                  <Grid item xs={6} className={classes.formInputField}>
-                    <TextField
-                      id="city"
-                      name="city"
-                      autoComplete="city"
-                      helperText={touched.city ? errors.city : ''}
-                      error={touched.city && Boolean(errors.city)}
-                      value={values.city}
-                      onChange={handleChange}
-                      size="small"
-                      variant="outlined"
-                      placeholder="Toronto"
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={2} />
-
-                  <Grid item xs={1}></Grid>
-                  <Grid item xs={3} className={classes.formLabel}>
-                    describe yourself
-                  </Grid>
-                  <Grid item xs={6} className={classes.formInputField}>
-                    <TextField
-                      id="description"
-                      name="description"
-                      helperText={touched.description ? errors.description : ''}
-                      error={touched.description && Boolean(errors.description)}
-                      value={values.description}
-                      onChange={handleChange}
-                      size="small"
-                      variant="outlined"
-                      multiline
-                      rows={4}
-                      placeholder="About you"
-                      fullWidth
-                    />
-                  </Grid>
-                  <Grid item xs={2} />
-                </Grid>
-                <Button color="primary" size="large" type="submit" variant="contained" className={classes.submitButton}>
-                  {isSubmitting ? <CircularProgress size={23} style={{ color: 'white' }} /> : 'Submit'}
+              <Grid item xs={2} />
+              <Grid item xs={2} className={classes.formLabel}>
+                phone number
+              </Grid>
+              <Grid item xs={6} className={classes.formInputField}>
+                <Button color="primary" variant="outlined" className={classes.buttonPhone}>
+                  Add a phone number
                 </Button>
-              </form>
-            )}
-          </Formik>
-        </Paper>
-      </Grid>
+              </Grid>
+              <Grid item xs={2} />
+
+              <Grid item xs={2} />
+              <Grid item xs={2} className={classes.formLabel}>
+                city you live in
+              </Grid>
+              <Grid item xs={6} className={classes.formInputField}>
+                <TextField
+                  id="city"
+                  name="city"
+                  autoComplete="city"
+                  helperText={touched.city ? errors.city : ''}
+                  error={touched.city && Boolean(errors.city)}
+                  value={values.city}
+                  onChange={handleChange}
+                  size="small"
+                  variant="outlined"
+                  placeholder="Toronto"
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={2} />
+
+              <Grid item xs={1}></Grid>
+              <Grid item xs={3} className={classes.formLabel}>
+                describe yourself
+              </Grid>
+              <Grid item xs={6} className={classes.formInputField}>
+                <TextField
+                  id="description"
+                  name="description"
+                  helperText={touched.description ? errors.description : ''}
+                  error={touched.description && Boolean(errors.description)}
+                  value={values.description}
+                  onChange={handleChange}
+                  size="small"
+                  variant="outlined"
+                  multiline
+                  rows={4}
+                  placeholder="About you"
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={2} />
+            </Grid>
+            <Button color="primary" size="large" type="submit" variant="contained" className={classes.submitButton}>
+              {isSubmitting ? <CircularProgress size={23} style={{ color: 'white' }} /> : 'Submit'}
+            </Button>
+          </form>
+        )}
+      </Formik>
     </Grid>
   );
 };

--- a/client/src/components/Payment/Payment.tsx
+++ b/client/src/components/Payment/Payment.tsx
@@ -1,19 +1,11 @@
-import { Grid, Paper } from '@material-ui/core';
-import Sidebar from '../Sidebar/SideBar';
+import { Grid } from '@material-ui/core';
 import useStyles from './useStyles';
 
 const Payment = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Grid container>
-      <Grid item xs={2}>
-        <Sidebar></Sidebar>
-      </Grid>
-      <Grid item xs={10}>
-        <Paper className={classes.root} elevation={2}>
-          <h1>Payment</h1>
-        </Paper>
-      </Grid>
+    <Grid>
+      <h1>Payment</h1>
     </Grid>
   );
 };

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -1,8 +1,7 @@
-import { Grid, Paper, CircularProgress, Typography, Button, Avatar } from '@material-ui/core';
+import { Grid, CircularProgress, Typography, Button, Avatar } from '@material-ui/core';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import React, { useState } from 'react';
 
-import Sidebar from '../Sidebar/SideBar';
 import useStyles from './useStyles';
 import AvatarDisplay from '../AvatarDisplay/AvatarDisplay';
 import { useAuth } from '../../context/useAuthContext';
@@ -47,34 +46,23 @@ const ProfilePhoto = (): JSX.Element => {
     return <CircularProgress />;
   }
   return (
-    <Grid container>
-      <Grid item xs={2}>
-        <Sidebar></Sidebar>
-      </Grid>
-      <Grid item xs={10}>
-        <Paper className={classes.root} elevation={2}>
-          <Grid container justify="center" className={classes.main}>
-            <Grid container alignItems="center" direction="column" className={classes.subMain}>
-              <Typography className={classes.title}>Profile Photo</Typography>
-              {url ? (
-                <Avatar src={url} className={classes.displayPic} />
-              ) : (
-                <AvatarDisplay loggedIn user={loggedInUser} className={classes.displayPic} />
-              )}
-              <Typography className={classes.explanation}>
-                Be sure to use a photo that clearly shows your face
-              </Typography>
-              <Button color="primary" variant="outlined" className={classes.buttonUpload} component="label">
-                Upload a file from your device
-                <input type="file" hidden onChange={handleInputChange} />
-              </Button>
-              <Button className={classes.buttonDelete} onClick={handleDelete}>
-                <DeleteOutlineIcon />
-                <Typography className={classes.textDelete}>Delete photo</Typography>
-              </Button>
-            </Grid>
-          </Grid>
-        </Paper>
+    <Grid container justify="center" className={classes.main}>
+      <Grid container alignItems="center" direction="column" className={classes.subMain}>
+        <Typography className={classes.title}>Profile Photo</Typography>
+        {url ? (
+          <Avatar src={url} className={classes.displayPic} />
+        ) : (
+          <AvatarDisplay loggedIn user={loggedInUser} className={classes.displayPic} />
+        )}
+        <Typography className={classes.explanation}>Be sure to use a photo that clearly shows your face</Typography>
+        <Button color="primary" variant="outlined" className={classes.buttonUpload} component="label">
+          Upload a file from your device
+          <input type="file" hidden onChange={handleInputChange} />
+        </Button>
+        <Button className={classes.buttonDelete} onClick={handleDelete}>
+          <DeleteOutlineIcon />
+          <Typography className={classes.textDelete}>Delete photo</Typography>
+        </Button>
       </Grid>
     </Grid>
   );

--- a/client/src/components/Security/Security.tsx
+++ b/client/src/components/Security/Security.tsx
@@ -1,18 +1,10 @@
-import { Grid, Paper } from '@material-ui/core';
-import Sidebar from '../Sidebar/SideBar';
+import { Grid } from '@material-ui/core';
 import useStyles from './useStyles';
 const Security = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Grid container>
-      <Grid item xs={2}>
-        <Sidebar></Sidebar>
-      </Grid>
-      <Grid item xs={10}>
-        <Paper className={classes.root} elevation={2}>
-          <h1>Security</h1>
-        </Paper>
-      </Grid>
+    <Grid>
+      <h1>Security</h1>
     </Grid>
   );
 };

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -1,19 +1,11 @@
-import { Grid, Paper } from '@material-ui/core';
-import Sidebar from '../Sidebar/SideBar';
+import { Grid } from '@material-ui/core';
 import useStyles from './useStyles';
 
 const Settings = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Grid container>
-      <Grid item xs={2}>
-        <Sidebar></Sidebar>
-      </Grid>
-      <Grid item xs={10}>
-        <Paper className={classes.root} elevation={2}>
-          <h1>Settings</h1>
-        </Paper>
-      </Grid>
+    <Grid>
+      <h1>Settings</h1>
     </Grid>
   );
 };

--- a/client/src/components/Sidebar/SideBar.tsx
+++ b/client/src/components/Sidebar/SideBar.tsx
@@ -20,22 +20,22 @@ const Sidebar = (): JSX.Element => {
     >
       <div className={classes.toolbar} />
       <List>
-        <ListItem button component={Link} to="/manageprofile/editprofile">
+        <ListItem button component={Link} to="/manage-profile/edit-profile">
           <ListItemText primary="Edit Profile" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/manageprofile/profilephoto">
+        <ListItem button component={Link} to="/manage-profile/profile-photo">
           <ListItemText primary="Profile Photo" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/manageprofile/availability">
+        <ListItem button component={Link} to="/manage-profile/availability">
           <ListItemText primary="Availability" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/manageprofile/payment">
+        <ListItem button component={Link} to="/manage-profile/payment">
           <ListItemText primary="Payment" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/manageprofile/security">
+        <ListItem button component={Link} to="/manage-profile/security">
           <ListItemText primary="Security" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/manageprofile/settings">
+        <ListItem button component={Link} to="/manage-profile/settings">
           <ListItemText primary="Settings" className={classes.listItem}></ListItemText>
         </ListItem>
       </List>

--- a/client/src/components/Sidebar/SideBar.tsx
+++ b/client/src/components/Sidebar/SideBar.tsx
@@ -20,22 +20,22 @@ const Sidebar = (): JSX.Element => {
     >
       <div className={classes.toolbar} />
       <List>
-        <ListItem button component={Link} to="/editprofile">
+        <ListItem button component={Link} to="/manageprofile/editprofile">
           <ListItemText primary="Edit Profile" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/profile/pics">
+        <ListItem button component={Link} to="/manageprofile/profilephoto">
           <ListItemText primary="Profile Photo" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/availability">
+        <ListItem button component={Link} to="/manageprofile/availability">
           <ListItemText primary="Availability" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/payment">
+        <ListItem button component={Link} to="/manageprofile/payment">
           <ListItemText primary="Payment" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/security">
+        <ListItem button component={Link} to="/manageprofile/security">
           <ListItemText primary="Security" className={classes.listItem}></ListItemText>
         </ListItem>
-        <ListItem button component={Link} to="/settings">
+        <ListItem button component={Link} to="/manageprofile/settings">
           <ListItemText primary="Settings" className={classes.listItem}></ListItemText>
         </ListItem>
       </List>

--- a/client/src/helpers/APICalls/createProfile.ts
+++ b/client/src/helpers/APICalls/createProfile.ts
@@ -2,18 +2,18 @@ import { ProfileApiData } from '../../interface/AuthApiData';
 import { FetchOptions } from '../../interface/FetchOptions';
 import { Profile } from '../../interface/Profile';
 
-const editProfile = async (id: string, profile: Profile): Promise<ProfileApiData> => {
+const createProfile = async (profile: Profile): Promise<ProfileApiData> => {
   const fetchOptions: FetchOptions = {
-    method: 'PATCH',
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(profile),
     credentials: 'include',
   };
-  return await fetch(`/profile/${id}`, fetchOptions)
+  return await fetch(`/profile`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },
     }));
 };
 
-export default editProfile;
+export default createProfile;

--- a/client/src/helpers/APICalls/getProfile.ts
+++ b/client/src/helpers/APICalls/getProfile.ts
@@ -1,12 +1,10 @@
 import { ProfileApiData } from '../../interface/AuthApiData';
 import { FetchOptions } from '../../interface/FetchOptions';
-import { Profile } from '../../interface/Profile';
 
-const editProfile = async (id: string, profile: Profile): Promise<ProfileApiData> => {
+const getUserProfile = async (id: string): Promise<ProfileApiData> => {
   const fetchOptions: FetchOptions = {
-    method: 'PATCH',
+    method: 'GET',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(profile),
     credentials: 'include',
   };
   return await fetch(`/profile/${id}`, fetchOptions)
@@ -16,4 +14,4 @@ const editProfile = async (id: string, profile: Profile): Promise<ProfileApiData
     }));
 };
 
-export default editProfile;
+export default getUserProfile;

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,21 +1,12 @@
 export interface Profile {
-  _id: string;
-  firstName: string;
-  lastName: string;
-  title?: string;
-  profilePic?: string;
-  description?: string;
-  wage: number;
-  ratings: Array<number>;
-  city: string;
-}
-export interface changeProfile {
   _id?: string;
   firstName?: string;
   lastName?: string;
+  email?: string;
   title?: string;
   profilePic?: string;
   description?: string;
+  phone?: number;
   wage?: number;
   ratings?: Array<number>;
   city?: string;

--- a/client/src/interface/User.ts
+++ b/client/src/interface/User.ts
@@ -1,6 +1,7 @@
 export interface User {
   email: string;
   username: string;
+  id?: string;
 }
 
 export interface SearchUsersApiData {

--- a/client/src/pages/ManageProfile/ManageProfile.tsx
+++ b/client/src/pages/ManageProfile/ManageProfile.tsx
@@ -25,22 +25,22 @@ export default function ManageProfile(): JSX.Element {
 
   const handleRoute = (path: string) => {
     switch (path) {
-      case '/manageprofile/editprofile':
+      case '/manage-profile/edit-profile':
         return <EditProfile _id={userId} profile={userProfile} />;
 
-      case '/manageprofile/profilephoto':
+      case '/manage-profile/profile-photo':
         return <ProfilePhoto />;
 
-      case '/manageprofile/payment':
+      case '/manage-profile/payment':
         return <Payment />;
 
-      case '/manageprofile/availability':
+      case '/manage-profile/availability':
         return <Availability />;
 
       case '/manageprofile/security':
         return <Security />;
 
-      case '/manageprofile/settings':
+      case '/manage-profile/settings':
         return <Settings />;
 
       default:
@@ -52,9 +52,9 @@ export default function ManageProfile(): JSX.Element {
     async function getProfileData() {
       if (userId)
         return await getUserProfile(userId).then((data) => {
-          if (!data?.success) {
-            setLoading(false);
-          } else setUserProfile(data.success.profile);
+          if (data?.success) {
+            setUserProfile(data.success.profile);
+          }
           setLoading(false);
         });
       else setLoading(false);
@@ -69,7 +69,7 @@ export default function ManageProfile(): JSX.Element {
       <Grid item xs={2}>
         <SideBar />
       </Grid>
-      <Grid item xs={10} style={{ backgroundColor: '#FAFAFA' }}>
+      <Grid item xs={10} className={classes.root}>
         <Paper elevation={3} className={classes.gridContainer}>
           {handleRoute(location.pathname)}
         </Paper>

--- a/client/src/pages/ManageProfile/ManageProfile.tsx
+++ b/client/src/pages/ManageProfile/ManageProfile.tsx
@@ -1,0 +1,79 @@
+import { CssBaseline, Grid, Paper, CircularProgress } from '@material-ui/core';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/useAuthContext';
+import useStyles from './useStyles';
+import { useEffect, useState } from 'react';
+
+import SideBar from '../../components/Sidebar/SideBar';
+import EditProfile from '../../components/EditProfile/EditProfile';
+import ProfilePhoto from '../../components/ProfilePhoto/ProfilePhoto';
+import Payment from '../../components/Payment/Payment';
+import Availability from '../../components/Availability/Availability';
+import Security from '../../components/Security/Security';
+import Settings from '../../components/Settings/Settings';
+import getUserProfile from '../../helpers/APICalls/getProfile';
+import { Profile } from '../../interface/Profile';
+
+export default function ManageProfile(): JSX.Element {
+  const classes = useStyles();
+  const [loading, setLoading] = useState(true);
+
+  const location = useLocation();
+  const userData = useAuth();
+  const userId = userData.loggedInUser?.id;
+  const [userProfile, setUserProfile] = useState<Profile>();
+
+  const handleRoute = (path: string) => {
+    switch (path) {
+      case '/manageprofile/editprofile':
+        return <EditProfile _id={userId} profile={userProfile} />;
+
+      case '/manageprofile/profilephoto':
+        return <ProfilePhoto />;
+
+      case '/manageprofile/payment':
+        return <Payment />;
+
+      case '/manageprofile/availability':
+        return <Availability />;
+
+      case '/manageprofile/security':
+        return <Security />;
+
+      case '/manageprofile/settings':
+        return <Settings />;
+
+      default:
+        return <EditProfile />;
+    }
+  };
+  useEffect(() => {
+    setLoading(true);
+    async function getProfileData() {
+      if (userId)
+        return await getUserProfile(userId).then((data) => {
+          if (!data?.success) {
+            setLoading(false);
+          } else setUserProfile(data.success.profile);
+          setLoading(false);
+        });
+      else setLoading(false);
+    }
+    getProfileData();
+  }, [userId]);
+  if (userId === undefined) return <CircularProgress />;
+  if (loading) return <CircularProgress />;
+  return (
+    <Grid container>
+      <CssBaseline />
+      <Grid item xs={2}>
+        <SideBar />
+      </Grid>
+      <Grid item xs={10} style={{ backgroundColor: '#FAFAFA' }}>
+        <Paper elevation={3} className={classes.gridContainer}>
+          {handleRoute(location.pathname)}
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/client/src/pages/ManageProfile/useStyles.ts
+++ b/client/src/pages/ManageProfile/useStyles.ts
@@ -2,7 +2,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
   root: {
-    flex: 1,
+    backgroundColor: '#FAFAFA',
   },
   gridContainer: {
     margin: '5% 15% 0% 15%',

--- a/client/src/pages/ManageProfile/useStyles.ts
+++ b/client/src/pages/ManageProfile/useStyles.ts
@@ -1,0 +1,15 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    flex: 1,
+  },
+  gridContainer: {
+    margin: '5% 15% 0% 15%',
+    padding: '1%',
+    justifyContent: 'center',
+    minHeight: '500px',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,16 +1,11 @@
-import CssBaseline from '@material-ui/core/CssBaseline';
-import Paper from '@material-ui/core/Paper';
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
+import { Paper, Box, Grid, CssBaseline, Typography, Button } from '@material-ui/core';
 import { FormikHelpers } from 'formik';
-import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import register from '../../helpers/APICalls/register';
 import SignUpForm from './SignUpForm/SignUpForm';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
-import { Button } from '@material-ui/core';
 import login from '../../helpers/APICalls/login';
 import dogs from '../../Images/goldenRetrievers.jpg';
 import LandingPageBar from '../../components/LandingPageBar/LandingPageBar';

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -15,7 +15,7 @@ exports.createProfile = asyncHandler(async (req, res, next) => {
     throw new Error("Profile could not be created.");
   }
   await newProfile.save();
-  res.status(201).json({ profile: newProfile });
+  res.status(201).json({ success: { profile: newProfile } });
 });
 
 // @route GET /profile
@@ -32,12 +32,12 @@ exports.allProfiles = asyncHandler(async (req, res, next) => {
 // @route GET /profile/:id
 // Search profiles for matching id
 exports.searchProfiles = asyncHandler(async (req, res, next) => {
-  const profile = await Profile.findById(req.profile.id);
+  const profile = await Profile.findById(req.params.id);
   if (!profile) {
     res.status(404);
     throw new Error("Cannot find a matching profile.");
   }
-  res.status(200).json({ success: profile });
+  res.status(200).json({ success: { profile } });
 });
 
 // @route PATCH /profile/:id

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -1,54 +1,53 @@
 const mongoose = require("mongoose");
 
 const profileSchema = new mongoose.Schema({
-    userId: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: "user",
-    },
-    firstName: {
-        type: String,
-        required: true,
-    },
-    lastName: {
-        type: String,
-        required: true,
-    },
-    address: {
-        type: String,
-        required: true,
-    },
-    city: String,
-    phoneNumber: Number,
-    profilePic: String,
-    aboutMe: String,
-    gender: String,
-    isSitter: {
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "user",
+  },
+  firstName: {
+    type: String,
+    required: true,
+  },
+  lastName: {
+    type: String,
+    required: true,
+  },
+  email: String,
+  address: String,
+  city: String,
+  phoneNumber: Number,
+  profilePic: String,
+  aboutMe: String,
+  gender: String,
+  isSitter: {
+    type: Boolean,
+    required: true,
+    default: false,
+  },
+  availability: [
+    {
+      day: String,
+      morning: {
         type: Boolean,
-        required: true,
-        default: false,
+        default: true,
+      },
+      afternoon: {
+        type: Boolean,
+        default: true,
+      },
+      evening: {
+        type: Boolean,
+        default: true,
+      },
+      night: {
+        type: Boolean,
+        default: true,
+      },
     },
-    availability: [{
-        day: String,
-        morning: {
-            type: Boolean,
-            default: true,
-        },
-        afternoon: {
-            type: Boolean,
-            default: true,
-        },
-        evening: {
-            type: Boolean,
-            default: true,
-        },
-        night: {
-            type: Boolean,
-            default: true,
-        },
-    }, ],
+  ],
 
-    wage: Number,
-
+  wage: Number,
 });
 
 module.exports = Profile = mongoose.model("profile", profileSchema);

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -13,7 +13,7 @@ const {
 router.route("/").post(protect, createProfile);
 router.route("/").get(allProfiles);
 router.route("/:id").get(searchProfiles);
-router.route("/:id").patch(editProfile);
+router.route("/:id").patch(protect, editProfile);
 router.route("/:id").delete(protect, deleteProfile);
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Re-routes all profile related pages so they are a child of one new page.
- In the new page fetching profile data from the database to pass down to children via props
- Now creates a new profile if one is not found in the database when Editing profile (I wasn't sure how we want to deal with this but the framework is setup in editProfile page for now)

### Screenshots / Videos (required):
- N/A


### Any issues with the current functionality (optional):
- Need to confirm that the pages properly get profile data before loading is set to false (I did a bit, but am still not confident)